### PR TITLE
Fix README content and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,46 @@
 # axell.dev
 <div align="center">
 
-
 ### My blog
 
-![logo](./assets/img/git-logo.png.png)
+![logo](./assets/img/git-logo.png)
 
 Blog is available at [blog.axell.dev](https://blog.axell.dev).
 
 </div>
 
-## ♟️ Specs
+## ♟️ Stack
 
-My blog hosted on cloudflare pages and generated with [Hugo](https://gohugo.io/).
-The theme I am using is [blowfish](https://github.com/nunocoracao/blowfish)
+- **Generator**: [Hugo](https://gohugo.io/)
+- **Theme**: [Blowfish](https://github.com/nunocoracao/blowfish)
+- **Hosting**: [Cloudflare Pages](https://pages.cloudflare.com/)
+- **DNS**: [Cloudflare](https://cloudflare.com/)
+
+## 🚀 Local Development
+
+```bash
+# Serve with live reload
+just dev
+
+# Build for production
+just build
+```
+
+## 📁 Structure
+
+```
+config/_default/   # Hugo configuration (params, menus, languages)
+content/           # Blog posts, about, projects pages
+assets/img/        # Images and logos
+layouts/partials/  # Theme overrides and extensions
+static/            # Static files served as-is
+themes/blowfish/   # Theme submodule
+```
 
 ## ℹ️ About
 
-I made post about how I recetly migrated from ghost to hugo, you can read it [here](https://blog.axell.dev/posts/why-i-migrated-from-ghost-to-hugo-and-cloudflare/)
+I wrote a post about migrating from Ghost to Hugo — read it [here](https://blog.axell.dev/favorite/why-i-migrated-from-ghost-to-hugo-and-cloudflare/).
 
 ## External Dependencies
 
-This project includes the following external dependencies:
-
-- **Theme Submodule**: Located in the `theme` directory, this submodule is licensed under the MIT License. More details can be found in the submodule's repository [here](https://github.com/nunocoracao/blowfish?tab=MIT-1-ov-file)
+- **Theme submodule** (`themes/blowfish`): licensed under the [MIT License](https://github.com/nunocoracao/blowfish?tab=MIT-1-ov-file)


### PR DESCRIPTION
Correct the logo path and reorganize README sections for clarity. Update
the "Specs" section to "Stack", add local development commands and a
project structure overview, and fix the blog post link. Also simplify the
external dependency note for the theme submodule.